### PR TITLE
Flickr feed thumbnail data

### DIFF
--- a/core/components/spiefeed/model/spiefeed.class.php
+++ b/core/components/spiefeed/model/spiefeed.class.php
@@ -215,6 +215,14 @@ class SimplePieModx {
                 } elseif ($feed->get_type() & SIMPLEPIE_TYPE_ALL) {
                     $phArray[$joinKey]['getType'] = 'Supported';
                 }
+				
+				// Media from Flickr RSS stream
+				if ($enclosure = $item->get_enclosure()) {
+						$phArray[$joinKey]['itemImageThumbnailUrl'] = $enclosure->get_thumbnail();
+						$phArray[$joinKey]['itemImageWidth'] = $enclosure->get_width();
+						$phArray[$joinKey]['itemImageHeight'] = $enclosure->get_height();
+				}
+				
 
                 $countLimit++;
                 $joinKey++;


### PR DESCRIPTION
This patch allow spiefeed to access thumbnail and original image width / height data from Flickr's RSS 2.0  feeds.
